### PR TITLE
disable 'edit on github' button option for all pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ site_author: ASF APD/Tools Team
 site_description: The Alaska Satellite Facility's Hybrid Pluggable Processing Pipeline
 copyright: © 2020 Alaska Satellite Facility
 google_analytics: ['UA-991100-5', 'search.asf.alaska.edu']
+edit_uri: ''
 
 theme:
   name: "material"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,6 @@ site_author: ASF APD/Tools Team
 site_description: The Alaska Satellite Facility's Hybrid Pluggable Processing Pipeline
 copyright: © 2020 Alaska Satellite Facility
 google_analytics: ['UA-991100-5', 'search.asf.alaska.edu']
-edit_uri: ''
 
 theme:
   name: "material"
@@ -17,6 +16,7 @@ theme:
 
 repo_url: https://github.com/ASFHyP3
 repo_name: ASF HyP3
+edit_uri: ''
 
 extra:
   social:


### PR DESCRIPTION
This removes the non-functional 'edit on github' button at the top right of each page.
![Screenshot from 2020-10-19 19-51-26](https://user-images.githubusercontent.com/17994518/96538246-9877db80-1244-11eb-9bd5-6a8267fe2ec0.png)

Full documentation at https://www.mkdocs.org/user-guide/configuration/#edit_uri , specifically `If you do not want any "edit URL link" displayed on your pages, then set edit_uri to an empty string to disable the automatic setting.`

If we ever want the button back, we'll want to set `edit_uri` to point at `main` instead of the default of `master` to make it functional.