### PR TITLE
Update site URL for analytics

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://hyp3-docs.asf.alaska.edu/
 site_author: ASF APD/Tools Team
 site_description: The Alaska Satellite Facility's Hybrid Pluggable Processing Pipeline
 copyright: © 2020 Alaska Satellite Facility
-google_analytics: ['UA-991100-9', 'hyp3-docs.asf.alaska.edu']
+google_analytics: ['UA-991100-5', 'search.asf.alaska.edu']
 
 theme:
   name: "material"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,9 @@
 site_name: HyP3
-site_url: https://ASFHyP3.github.io/
+site_url: https://hyp3-docs.asf.alaska.edu/
 site_author: ASF APD/Tools Team
 site_description: The Alaska Satellite Facility's Hybrid Pluggable Processing Pipeline
 copyright: © 2020 Alaska Satellite Facility
-google_analytics: ['UA-991100-5', 'search.asf.alaska.edu']
+google_analytics: ['UA-991100-9', 'hyp3-docs.asf.alaska.edu']
 
 theme:
   name: "material"


### PR DESCRIPTION
Our sitemap and canonical urls in page headers will refer for `hyp3-docs.asf.alaska.edu` instead of `asfhyp3.github.io`