### PR TITLE
Add search bar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
   - Code of Conduct: CODE_OF_CONDUCT.md
 
 plugins:
+  - search
   - gitsnippet
   - mkdocstrings:
       handlers:


### PR DESCRIPTION
MkDocs enables search by default if `plugins:` is empty in `mkdocs.yml`, but must be explicitly enabled otherwise. 
