### PR TITLE
ASF Tools and menus 

### DIFF
--- a/.github/workflows/update_asf_tools_version.yml
+++ b/.github/workflows/update_asf_tools_version.yml
@@ -1,15 +1,15 @@
-name: Update HyP3 SDK version
+name: Update ASF Tools version
 
 on:
   workflow_dispatch:
     inputs:
-      sdk_version:
-        desription: 'The new version of the SDK'
+      asf_tools_version:
+        desription: 'The new version of ASF Tools'
         required: true
 
 jobs:
   bump_sdk_version:
-    name: Bump the SDK version
+    name: Bump the ASF Tools version
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
@@ -19,16 +19,16 @@ jobs:
       - name: create patch branch
         id: patch
         env:
-          SDK_VERSION: ${{ github.event.inputs.sdk_version }}
-          PATCH_BRANCH: bumb-sdk-${{ github.event.inputs.sdk_version }}
+          ASF_TOOLS_VERSION: ${{ github.event.inputs.asf_tools_version }}
+          PATCH_BRANCH: bumb-asf-tools-${{ github.event.inputs.asf_tools_version }}
         run: |
           git config user.name "tools-bot"
           git config user.email "UAF-asf-apd@alaska.edu"
           echo "::set-output name=branch::${PATCH_BRANCH}"
           git checkout -b ${PATCH_BRANCH}
-          grep -lr "hyp3-sdk.git" | xargs sed -i -r "s/v[0-9]+\.[0-9]+\.[0-9]+/${SDK_VERSION}/"
-          sed -i -r "s/hyp3_sdk==[0-9]+\.[0-9]+\.[0-9]+/hyp3_sdk==${SDK_VERSION#v}/" conda-env.yml
-          git commit -am "Bump SDK version to ${SDK_VERSION}"
+          grep -lr "asf-tools.git" | xargs sed -i -r "s/v[0-9]+\.[0-9]+\.[0-9]+/${ASF_TOOLS_VERSION}/"
+          sed -i -r "s/asf_tools==[0-9]+\.[0-9]+\.[0-9]+/asf_tools==${ASF_TOOLS_VERSION#v}/" conda-env.yml
+          git commit -am "Bump ASF Tools version to ${ASF_TOOLS_VERSION}"
           git push origin ${PATCH_BRANCH}
 
       - name: open PR
@@ -36,7 +36,7 @@ jobs:
         with:
           source_branch:  ${{ steps.patch.outputs.branch }}
           destination_branch: main
-          pr_title: Update HyP3 SDK version to ${{ github.event.inputs.sdk_version }}
+          pr_title: Update ASF Tools version to ${{ github.event.inputs.asf_tools_version }}
           pr_body: |
             PR created by a `workflow_dispatch` event
           pr_assignee: ASFHyP3/tools

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -13,5 +13,6 @@ dependencies:
       # For documentation
       - hyp3_sdk==0.3.3  # also pinned in docs/using/sdk.md
       - asf_tools==0.2.0  # also pinned in docs/tools/asf_tools.md
+      - mkdocs-section-index
       - mkdocstrings
       - git+https://github.com/Jlrine2/mkdocs-gitsnippet-plugin.git

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -12,5 +12,6 @@ dependencies:
   - pip:
       # For documentation
       - hyp3_sdk==0.3.3  # also pinned in docs/using/sdk.md
+      - asf_tools==0.2.0  # also pinned in docs/tools/asf_tools.md
       - mkdocstrings
       - git+https://github.com/Jlrine2/mkdocs-gitsnippet-plugin.git

--- a/docs/tools/asf_tools.md
+++ b/docs/tools/asf_tools.md
@@ -1,1 +1,1 @@
-{{ gitsnippet('https://github.com/ASFHyP3/asf-tools.git', 'asf_tools/README.md', '', 'main') }}
+{{ gitsnippet('https://github.com/ASFHyP3/asf-tools.git', 'asf_tools/README.md', '', 'v0.2.0') }}

--- a/docs/tools/asf_tools_api.md
+++ b/docs/tools/asf_tools_api.md
@@ -1,3 +1,3 @@
-# ASF Tools for Python
+# `asf_tools` API Reference
 
 ::: asf_tools

--- a/docs/tools/asf_tools_api.md
+++ b/docs/tools/asf_tools_api.md
@@ -1,0 +1,3 @@
+# ASF Tools for Python
+
+::: asf_tools

--- a/docs/using/sdk.md
+++ b/docs/using/sdk.md
@@ -1,1 +1,1 @@
-{{ gitsnippet('https://github.com/ASFHyP3/hyp3-sdk.git', 'docs/index.md', '', 'v0.3.3') }}
+{{ gitsnippet('https://github.com/ASFHyP3/hyp3-sdk.git', 'README.md', '', 'v0.3.3') }}

--- a/docs/using/sdk_api.md
+++ b/docs/using/sdk_api.md
@@ -1,0 +1,3 @@
+# SDK API Reference
+
+::: hyp3_sdk

--- a/docs/using/sdk_api.md
+++ b/docs/using/sdk_api.md
@@ -1,3 +1,3 @@
-# SDK API Reference
+# `hyp3_sdk` API Reference
 
 ::: hyp3_sdk

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,4 +68,6 @@ plugins:
   - mkdocstrings:
       handlers:
           python:
-            inherited_members: True
+            inherited_members: true
+            rendering:
+              show_root_toc_entry: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,23 +35,27 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - Getting started: getting_started.md
   - Using HyP3:
+      - getting_started.md
       - Vertex: using/vertex.md
-      - SDK: using/sdk.md
+      - SDK:
+        - using/sdk.md
+        - API Reference: using/sdk_api.md
       - API: using/api.md
   - Products:
-      - Overview: products.md
+      - products.md
       - Digital Elevation Models: dems.md
       - Product guides:
           - RTC Product Guide: guides/rtc_product_guide.md
           - RTC ATBD: guides/rtc_atbd.md
   - Other tools:
       - ArcGIS Toolbox: tools/arcgis_toolbox.md
-      - ASF Tools for Python: tools/asf_tools.md
+      - ASF Tools for Python:
+        - tools/asf_tools.md
+        - API Reference: tools/asf_tools_api.md
       # - hyp3lib: tools/hyp3lib.md
   - Plugins:
-      - Overview: plugins.md
+      - plugins.md
       # - HyP3 GAMMA: plugins/gamma.md
       # - HyP3 autoRIFT: plugins/autoRIFT.md
   - Contributing: contributing.md
@@ -60,6 +64,7 @@ nav:
 plugins:
   - search
   - gitsnippet
+  - section-index
   - mkdocstrings:
       handlers:
           python:


### PR DESCRIPTION
* auto-generates `asf_tools` API reference
* Pins the `asf_tools` version and adds a version bumping workflow (like SDK)

Also:
* Reorgs the menus to have section headers *with* content via `mkdocs-section-index`

While not required for this merge, upon the next release of `asf_tools` and `hyp3_sdk` we'll see some improvements in both of those tools documentations:
* ASFHyP3/asf-tools#69
* ASFHyP3/hyp3-sdk#58

* fixes #38