### PR TITLE
Update mkdocs-asf-theme to 0.2.1+

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -13,7 +13,7 @@ dependencies:
   - asf_tools=0.2.0  # also pinned in docs/tools/asf_tools.md
   - pip:
       # For documentation
-      - mkdocs-asf-theme>=0.2.0
+      - mkdocs-asf-theme>=0.2.1
       - mkdocs-section-index
       - mkdocstrings
       - git+https://github.com/Jlrine2/mkdocs-gitsnippet-plugin.git


### PR DESCRIPTION
[Update mkdocs-asf-theme to 0.2.1+](https://github.com/ASFHyP3/mkdocs-asf-theme/blob/develop/CHANGELOG.md#021)

Fixes dynamic copyright year eating page