### PR TITLE
Add SDK example notebook

### DIFF
--- a/docs/using/sdk_example.md
+++ b/docs/using/sdk_example.md
@@ -1,0 +1,4 @@
+<h1></h1>
+<iframe src="https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-sdk/blob/main/docs/sdk_example.ipynb" 
+        width='960' height='1024' allowfullscreen webkitallowfullscreen>
+</iframe>

--- a/docs/using/sdk_example.md
+++ b/docs/using/sdk_example.md
@@ -1,4 +1,0 @@
-<h1></h1>
-<iframe src="https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-sdk/blob/main/docs/sdk_example.ipynb" 
-        width='960' height='1024' allowfullscreen webkitallowfullscreen>
-</iframe>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,10 +33,10 @@ nav:
   - Home: index.md
   - Using HyP3:
       - getting_started.md
-      - Vertex: https://search.asf.alaska.edu/#/?topic=onDemand
+      - Vertex: https://search.asf.alaska.edu/#/?topic=onDemand" target="_blank
       - SDK:
         - using/sdk.md
-        - Example Notebook: using/sdk_example.md
+        - Example Notebook: https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-sdk/blob/main/docs/sdk_example.ipynb" target="_blank
         - API Reference: using/sdk_api.md
       - API: using/api.md
   - Products:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
       - Vertex: https://search.asf.alaska.edu/#/?topic=onDemand
       - SDK:
         - using/sdk.md
+        - Example Notebook: using/sdk_example.md
         - API Reference: using/sdk_api.md
       - API: using/api.md
   - Products:


### PR DESCRIPTION
This uses [Jupyter NBViewer](https://nbviewer.jupyter.org) in an `iframe` to get a static view of the notebook inside our documentation, which can also be launched on [binder]( https://mybinder.org) (binder badge in notebook). 

* GitHub view of the notebook: https://github.com/ASFHyP3/hyp3-sdk/blob/main/docs/sdk_example.ipynb
* NBViewer of this branch: https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-sdk/blob/main/docs/sdk_example.ipynb
* Binder of this branch: https://mybinder.org/v2/gh/ASFHyP3/hyp3-sdk/main?filepath=docs%2Fsdk_example.ipynb


#### other options

* There are at least 3 different MkDocs plugins that convert a notebook to HTML for rendering, and I played with all three of them. I ended up not liking any of them because they lose the look and feel of a Jupyter notebook without adding custom CSS, and what CSS was included conflicted with other parts of our CSS. Furthermore, getting a nice link out to binder, and download of the source notebooks wasn't particularly smooth in any of them.

* I could also just *direct link to binder* but I didn't really like that because
  * you leave our documentation
  * Binder takes a *long time* to spin up
  * While Jupyter NBViewer is included on the Binder startup page, the binder logo and log messages take a lot of real estate and take too much of the focus from the notebook. 

